### PR TITLE
Update for Blender 2.81+

### DIFF
--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -639,7 +639,8 @@ class DaeExporter:
             bm.free()
 
         #mesh.update(calc_tessface=True)# 2.79
-        mesh.update(calc_edges=False, calc_edges_loose=False, calc_loop_triangles=True)# 2.80
+        #mesh.update(calc_edges=False, calc_edges_loose=False, calc_loop_triangles=True)# 2.80
+        mesh.update(calc_edges=False, calc_edges_loose=False)# 2.81
         vertices = []
         vertex_map = {}
         surface_indices = {}


### PR DESCRIPTION
`mesh.update()` was changed to only take two positional arguments in 2.81.
[Docs here](https://docs.blender.org/api/current/bpy.types.Mesh.html?highlight=mesh%20update#bpy.types.Mesh.update).
