### PR TITLE
fix armature check and mesh.update

### DIFF
--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -480,8 +480,9 @@ class DaeExporter:
                 print(v)
                 # Warning, Blender 2.8 does not support anymore the "RENDER" argument to apply modifier
                 # with render state only...
-                
-                armature_modifier.show_viewport = armature_modifier_state
+
+                if(armature_modifier): #check if armature exists before checking, fixes issue with including armature
+                    armature_modifier.show_viewport = armature_modifier_state
                 
                 self.temp_meshes.add(v)
                 deps = bpy.context.evaluated_depsgraph_get()
@@ -639,7 +640,7 @@ class DaeExporter:
             bm.free()
 
         #mesh.update(calc_tessface=True)# 2.79
-        mesh.update(calc_edges=False, calc_edges_loose=False, calc_loop_triangles=True)# 2.80
+        mesh.update(calc_edges=False, calc_edges_loose=False)# 2.90
         vertices = []
         vertex_map = {}
         surface_indices = {}


### PR DESCRIPTION
Just added check for armature before .viewport call since when I unselected the "Excluded Armature" option, it errored out with None type has no viewport attribute.

Also fixed the mesh.update for 2.9.